### PR TITLE
feat: Have only one active debugger connection

### DIFF
--- a/emmy_core.go
+++ b/emmy_core.go
@@ -1,9 +1,19 @@
 package lua_debugger
 
 import (
-	lua "github.com/yuin/gopher-lua"
+	"io"
 	"log"
+	"sync/atomic"
+
+	lua "github.com/yuin/gopher-lua"
 )
+
+// openConn tracks open connection
+// This is necessary because otherwise debugger
+// (at least in InteliJ) will not work with multiple connected debuggers
+// at the same time. So we try to guard ourselves
+// to not deadlock incoming requests to NNBB Hub.
+var openConn int32
 
 func init() {
 	log.SetFlags(log.Ldate | log.Ltime | log.Lshortfile)
@@ -13,35 +23,40 @@ const (
 	KeyDebuggerFcd = "__Debugger_Fcd"
 )
 
-func TcpConnect(L *lua.LState) int {
+func (f *Facade) Connect(L *lua.LState) int {
 	host := L.CheckString(1)
 	port := L.CheckNumber(2)
+	// If no connections opened yet - we can open one.
+	if atomic.CompareAndSwapInt32(&openConn, 0, 1) {
+		if err := f.TcpConnect(L, host, int(port)); err != nil {
+			L.Push(lua.LFalse)
+			L.Push(lua.LString(err.Error()))
+			return 2
+		}
+	}
 
+	L.Push(lua.LTrue)
+	return 1
+}
+
+func (f *Facade) Loader(L *lua.LState) int {
+	t := L.NewTable()
+	L.SetFuncs(t, map[string]lua.LGFunction{
+		"tcpConnect": f.Connect,
+	})
+	L.Push(t)
+	return 1
+}
+
+func Preload(L *lua.LState) io.Closer {
+	// Creating facade here to track what to close
+	// when debugger should be finished.
 	fcd := newFacade()
 	fcdUd := L.NewUserData()
 	fcdUd.Value = fcd
 	L.SetField(L.Get(lua.RegistryIndex), KeyDebuggerFcd, fcdUd)
 
-	if err := fcd.TcpConnect(L, host, int(port)); err != nil {
-		L.Push(lua.LFalse)
-		L.Push(lua.LString(err.Error()))
-		return 2
-	}
-	L.Push(lua.LTrue)
-	return 1
-}
+	L.PreloadModule("emmy_core", fcd.Loader)
 
-var coreApi = map[string]lua.LGFunction{
-	"tcpConnect": TcpConnect,
-}
-
-func Loader(L *lua.LState) int {
-	t := L.NewTable()
-	L.SetFuncs(t, coreApi)
-	L.Push(t)
-	return 1
-}
-
-func Preload(L *lua.LState) {
-	L.PreloadModule("emmy_core", Loader)
+	return fcd
 }

--- a/transport.go
+++ b/transport.go
@@ -5,11 +5,12 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"github.com/edolphin-ydf/gopherlua-debugger/proto"
 	"io"
 	"log"
 	"net"
 	"strconv"
+
+	"github.com/edolphin-ydf/gopherlua-debugger/proto"
 )
 
 type Transport struct {
@@ -85,4 +86,12 @@ func (t *Transport) Send(cmd int, msg interface{}) {
 	if _, err := io.Copy(t.c, &buf); err != nil {
 		log.Println("send msg fail:", string(data), err)
 	}
+}
+
+func (t *Transport) Close() error {
+	if t.c != nil {
+		return t.c.Close()
+	}
+
+	return nil
 }


### PR DESCRIPTION
Before we start: Lua debugging works by implementing client-server configuration, where client is this library in NNBB Hub, and server is EmmyLua plugin running somewhere else(like IntelliJ or VSCode).

Issue with debugger library was that it did not close debugger connection when script finished execution, and when next(parallel) execution started - debugger library tried to connect to EmmyLua, which accepted connection, but did not provide any requests to debugger. This would lead to deadlock.

This MR fixes it by having only one open connection at a time and returning `io.Closer` that will close the connection when script execution finishes.

There will be separate MR to stream-services repository to update it to use this library.